### PR TITLE
fix: add AlmaLinux 9 appstream 1.26

### DIFF
--- a/build
+++ b/build
@@ -44,6 +44,7 @@ Usage:
         ${PACKAGER} almalinux:9
         ${PACKAGER} almalinux:9:appstream:1.22
         ${PACKAGER} almalinux:9:appstream:1.24
+        ${PACKAGER} almalinux:9:appstream:1.26
 
     Build for RHEL/AlmaLinux/Rocky Linux 8 + AppStream module:
         # build almalinux:8 (version 1.14 is not supported)


### PR DESCRIPTION
Add the missing AlmaLinux 9 AppStream 1.26 example to the build script usage text so the documented supported targets match the release matrix.